### PR TITLE
Set $USER variable in init script

### DIFF
--- a/templates/default/eye_init.lsb.erb
+++ b/templates/default/eye_init.lsb.erb
@@ -15,6 +15,7 @@ EYE=<%= node["eye"]["bin"] %>
 CONFIG_FILE=<%= @config_file %>
 SERVICE_NAME=<%= @service_name %>
 RUNAS=<%= @user || "root" %>
+USER=`id -nu`
 
 execute() {
   CMD="$EYE $1 $2"


### PR DESCRIPTION
In my testing, the `$USER` variable is not actually available in init scripts by default. This line sets it based on the output of `id -nu`.
